### PR TITLE
Update caching_synthesizer.py, save_as_wav()

### DIFF
--- a/vocode/streaming/synthesizer/caching_synthesizer.py
+++ b/vocode/streaming/synthesizer/caching_synthesizer.py
@@ -1,6 +1,8 @@
 import hashlib
 import os
 import re
+from pathlib import Path
+
 from typing import Any, AsyncGenerator, Callable, Optional, List, Union
 import wave
 from vocode.streaming.agent.bot_sentiment_analyser import BotSentiment
@@ -11,10 +13,9 @@ from vocode.streaming.models.synthesizer import SynthesizerConfig
 from vocode.streaming.models.transcriber import TranscriberConfig
 from vocode.streaming.synthesizer.base_synthesizer import BaseSynthesizer, FillerAudio, SynthesisResult, ChunkResult
 
-
 def save_as_wav(path, audio_data: bytes, config: Union[SynthesizerConfig, TranscriberConfig]):
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "wb") as f:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(path, "wb") as wav_file:
         wav_file = wave.open(f, "wb")
         wav_file.setnchannels(1)
         assert config.audio_encoding == AudioEncoding.LINEAR16


### PR DESCRIPTION
Defines `os.path.dirname(path)` as the parent directories of the Path object for the input string. Race condition occurs upon invoking `os.path.dirname(path)` specifically in the instance where `path` may not exist.

This is where the race condition occurs:
```
path = 'cache'
print(path)
# Returns Empty if directory does not exist
print(os.path.dirname(path))

# Returns False, if directory does not exist
print(os.path.exists(path))

# os.makedirs(os.path.dirname(path), exist_ok=True)

if (os.path.exists(path)):
    print('Path exists.')
    print(os.path.exists(path))
else: 
    print('Path does not exist.')
    print('Creating directories.')
    os.makedirs(os.path.dirname(path), exist_ok=True)
```

`save_as_wav` is called when the branch condition `if os.path.exists(cached_path)` fails.
`os.path.dirname(path)` by definition returns the directory name of pathname path.
This is the first element of the pair returned by passing path to the function [split()](https://docs.python.org/3/library/os.path.html#os.path.split)

The input for `save_as_wav` is follows:
```
 Replication
# save_as_wav is expecting path : String
# in `create_speech`, it is called as:
# save_as_wav(cached_path, all_bytes, self.inner_synthesizer.get_synthesizer_config()),

# cached_path is defined:
# example: 'cache' + 'en-US-Neural2-G/synth_it-s-been-nothing-but-trouble-si_601f1ab0.wav'
# cache_key = {voice_id}/synth_{cleaned_text[:32]}_{hash_value}.wav
cached_path = os.path.join(CachingSynthesizer().cache_path, cache_key)

# self.cache_path is initialized in CachingSynthesizer
# This removes the attributes for BaseSynthesizer for clarity
class CachingSynthesizer():
    def __init__(self,
                 cache_path: str = "cache"):
        self.cache_path = cache_path
        os.makedirs(self.cache_path, exist_ok=True)

# returns 'cache'
print(CachingSynthesizer().cache_path)
```

It's not entirely obvious what method is most effective here given the mixed handling of Path objects and strings.

For review, please read about the issues posed by various methods: https://stackoverflow.com/questions/273192/how-do-i-create-a-directory-and-any-missing-parent-directories