### PR TITLE
Fix base_synthesizer.py, test_generator branch condition

### DIFF
--- a/vocode/streaming/synthesizer/base_synthesizer.py
+++ b/vocode/streaming/synthesizer/base_synthesizer.py
@@ -94,7 +94,7 @@ class FillerAudio:
 
         async def chunk_generator(chunk_transform=lambda x: x):
             for i in range(0, len(self.audio_data), chunk_size):
-                if i + chunk_size > len(self.audio_data):
+                if i + chunk_size >= len(self.audio_data):
                     yield ChunkResult(
                         chunk_transform(self.audio_data[i:]), True
                     )
@@ -199,7 +199,7 @@ class BaseSynthesizer(Generic[SynthesizerConfigType]):
 
         async def chunk_generator(output_bytes):
             for i in range(0, len(output_bytes), chunk_size):
-                if i + chunk_size > len(output_bytes):
+                if i + chunk_size >= len(output_bytes):
                     yield ChunkResult(
                         chunk_transform(output_bytes[i:]), True
                     )


### PR DESCRIPTION
Improper branch condition.
Without 'greater than or equal to', statement is never True.
This is equivalent to the following:

```
async def test_generator(output_bytes):
            for i in range(0, len(data), chunk_size):
                if i + chunk_size >= len(output_bytes):
                    yield output_bytes[i:], True
                else:
                    yield output_bytes[i:i+chunk_size], False
```

Additionally, instead of using a branch condition, we can take advantage of function definitions.
```
async def test_generator(data: bytes, chunk_size: int):
    total_length = len(data)
    for i in range(0, total_length, chunk_size):
        is_last_chunk = i + chunk_size >= total_length
        yield data[i:i+chunk_size], is_last_chunk
```
This is more succinct but less obvious.