### PR TITLE
Update caching_synthesizer.py, AsyncGeneratorWrapper

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -563,7 +563,6 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     )
                 )
                 await synthesis_result.chunk_generator.__aclose__()
-                value = synthesis_result.chunk_generator.when_finished
                 message_sent = f"{synthesis_result.get_message_up_to(chunk_idx * seconds_per_chunk)}-"
                 cut_off = True
                 break

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -319,12 +319,6 @@ class StreamingConversation(Generic[OutputDeviceType]):
                         message_sent
                     )
                     metadata["cut_off"] = True
-                    if synthesis_result.cached_path:
-                        # "Uncache" the file that was cut off and isn't suitable to cache
-                        try:
-                            os.remove(synthesis_result.cached_path)
-                        except OSError:
-                            pass
 
                 if self.conversation.bot_sentiment:
                     metadata["sentiment"] = self.conversation.bot_sentiment
@@ -562,7 +556,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                         chunk_idx
                     )
                 )
-                await synthesis_result.chunk_generator.__aclose__()
+                await synthesis_result.chunk_generator.aclose()
                 message_sent = f"{synthesis_result.get_message_up_to(chunk_idx * seconds_per_chunk)}-"
                 cut_off = True
                 break

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -562,6 +562,8 @@ class StreamingConversation(Generic[OutputDeviceType]):
                         chunk_idx
                     )
                 )
+                await synthesis_result.chunk_generator.__aclose__()
+                value = synthesis_result.chunk_generator.when_finished
                 message_sent = f"{synthesis_result.get_message_up_to(chunk_idx * seconds_per_chunk)}-"
                 cut_off = True
                 break

--- a/vocode/streaming/synthesizer/caching_synthesizer.py
+++ b/vocode/streaming/synthesizer/caching_synthesizer.py
@@ -62,9 +62,10 @@ class AsyncGeneratorWrapper(AsyncGenerator[ChunkResult, None]):
             self.all_bytes = None
             raise
     
-    async def __aclose__(self):
+    async def aclose(self):
         self.when_finished(self.all_bytes)
         self.all_bytes = None
+        await self.generator.aclose()
 
     async def asend(self, value):
         return await self.generator.asend(value)

--- a/vocode/streaming/synthesizer/caching_synthesizer.py
+++ b/vocode/streaming/synthesizer/caching_synthesizer.py
@@ -74,9 +74,12 @@ class AsyncGeneratorWrapper(AsyncGenerator[ChunkResult, None]):
             # When the generator is empty:
             # __anext__ will raise StopAsyncIteration
             # if not cut_off:
-            self.when_finished(self.all_bytes)
+            # will not reach value
+            # self.when_finished(self.all_bytes)
             self.all_bytes = None
             raise StopAsyncIteration
+        # captures value outside exception    
+        self.when_finished(self.all_bytes)
         return chunk_result
     
     async def asend(self, value):

--- a/vocode/streaming/synthesizer/google_synthesizer.py
+++ b/vocode/streaming/synthesizer/google_synthesizer.py
@@ -103,7 +103,7 @@ class GoogleSynthesizer(BaseSynthesizer[GoogleSynthesizerConfig]):
         in_memory_wav.setnchannels(1)
         in_memory_wav.setsampwidth(2)
         in_memory_wav.setframerate(output_sample_rate)
-        in_memory_wav.writeframes(response.audio_content)
+        in_memory_wav.writeframes(response.audio_content[44:])
         output_bytes_io.seek(0)
 
         return self.create_synthesis_result_from_wav(


### PR DESCRIPTION
Overview:

AsyncGeneratorWrapper is a wrapper for `AsyncGenerator[ChunkResult, None])`
This is a wrapper for using AsyncGenerator, for use as an AsyncIterator.

`__anext__()` will raise `StopAsyncIteration` when the generator is empty.

Please refer to [PEP-0492](https://peps.python.org/pep-0492/)
```
Coroutines are still based on generators internally. So, before PEP 479, there was no fundamental difference between

def g1():
    yield from fut
    return 'spam'

and

def g2():
    yield from fut
    raise StopIteration('spam')

And since [PEP 479](https://peps.python.org/pep-0479) is accepted and enabled by default for coroutines, the following example will have its StopIteration wrapped into a RuntimeError

async def a1():
    await fut
    raise StopIteration('spam')

The only way to tell the outside code that the iteration has ended is to raise something other than StopIteration. Therefore, a new built-in exception class StopAsyncIteration was added.

Moreover, with semantics from [PEP 479](https://peps.python.org/pep-0479), all StopIteration exceptions raised in coroutines are wrapped in RuntimeError.
```
---

This commit attempts to resolve behavior when returning AsyncGenerator as an AsyncIterator.