### PR TITLE
XML/SSML tags leaking into truncated message output during interrupt

### DIFF
--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -28,12 +28,13 @@ import azure.cognitiveservices.speech as speechsdk
 
 
 NAMESPACES = {
-    "": "https://www.w3.org/2001/10/synthesis",
     "mstts": "https://www.w3.org/2001/mstts",
+    "": "https://www.w3.org/2001/10/synthesis",
 }
 
-for prefix, uri in NAMESPACES.items():
-    ElementTree.register_namespace(prefix, uri)
+ElementTree.register_namespace("", NAMESPACES[""])
+ElementTree.register_namespace("mstts", NAMESPACES["mstts"])
+
 
 class WordBoundaryEventPool:
     def __init__(self):
@@ -215,9 +216,7 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
         seconds: int,
         word_boundary_event_pool: WordBoundaryEventPool,
     ) -> str:
-        
         events = word_boundary_event_pool.get_events_sorted()
-
         tree = ElementTree.fromstring(ssml)
         for event in events:
             if event["audio_offset"] > seconds:
@@ -291,8 +290,6 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
             )
         else:
             output_generator = chunk_generator(audio_data_stream)
-        self.logger.debug(f"SSML: {ssml}")
-        self.logger.debug(f"Message: {message}")
 
         return SynthesisResult(
             output_generator,

--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -192,7 +192,7 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
             silence = ElementTree.SubElement(
                 voice_root, "{%s}silence" % NAMESPACES.get("mstts")
             )
-            silence.set("strength", "x-weak")
+            silence.set("value", "250ms")
             silence.set("type", "Sentenceboundary")
         prosody = ElementTree.SubElement(voice_root, "prosody")
         prosody.set("pitch", f"{self.pitch}%")

--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -192,8 +192,8 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
             silence = ElementTree.SubElement(
                 voice_root, "{%s}silence" % NAMESPACES.get("mstts")
             )
-            silence.set("value", "500ms")
-            silence.set("type", "Tailing-exact")
+            silence.set("strength", "strong")
+            silence.set("type", "Sentenceboundary")
         prosody = ElementTree.SubElement(voice_root, "prosody")
         prosody.set("pitch", f"{self.pitch}%")
         prosody.set("rate", f"{self.rate}%")

--- a/vocode/streaming/synthesizer/azure_synthesizer.py
+++ b/vocode/streaming/synthesizer/azure_synthesizer.py
@@ -192,7 +192,7 @@ class AzureSynthesizer(BaseSynthesizer[AzureSynthesizerConfig]):
             silence = ElementTree.SubElement(
                 voice_root, "{%s}silence" % NAMESPACES.get("mstts")
             )
-            silence.set("strength", "strong")
+            silence.set("strength", "x-weak")
             silence.set("type", "Sentenceboundary")
         prosody = ElementTree.SubElement(voice_root, "prosody")
         prosody.set("pitch", f"{self.pitch}%")


### PR DESCRIPTION
Patches behavior around string method for escaping XML tags to return truncated text.
```                ssml_fragment = ssml[: event["text_offset"]]
                # TODO: this is a little hacky, but it works for now
                return ssml_fragment.split(">")[-1]
```
Interrupting messages in small timespans would occasionally return `ssml` tags.

Reproduction:
SSML tags are added in between word pool boundary events.
This is to create natural sounding pause breaks between sentences.
This is only triggered if there are one or more words to form boundary events.
If tags are malformed, then the index of the split does not properly escape by the character: `>`
This is easier to troubleshoot by asking the agent to supply SSML tags directly as output.

Solution:
Explicit reference to XML tree and namespaces.
These are already defined by `create_ssml`.
Extract the text this way, by isolating the XML structure.
Relying on string methods to traverse a tree structure will fail if the closing tags do not appear.