### PR TITLE
Handling non-alphanumeric input, `create_speech`

### DIFF
--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -148,9 +148,6 @@ class StreamingConversation(Generic[OutputDeviceType]):
             if transcription.is_final:
                 file_path = None
                 # If no duration, it's a text message and we don't need to handle the audio
-                self.conversation.logger.debug(f"total_audio_bytes: {self.conversation.total_audio_bytes}")
-                self.conversation.logger.debug(f"offset: {transcription.offset}")
-                self.conversation.logger.debug(f"duration: {transcription.duration}")
                 if transcription.duration:
                     file_path = f"cache/{self.conversation.id}/transcript_{len(self.conversation.transcript.event_logs)}.wav"
                     t_config = self.conversation.transcriber.get_transcriber_config()

--- a/vocode/streaming/streaming_conversation.py
+++ b/vocode/streaming/streaming_conversation.py
@@ -137,7 +137,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                     self.conversation.broadcast_interrupt()
                 )
                 if self.conversation.current_transcription_is_interrupt:
-                    self.conversation.logger.debug("sending interrupt")
+                    self.conversation.logger.debug("Sending interrupt")
                 self.conversation.logger.debug("Human started speaking")
 
             transcription.is_interrupt = (
@@ -393,7 +393,7 @@ class StreamingConversation(Generic[OutputDeviceType]):
                 )
                 item.agent_response_tracker.set()
                 self.conversation.logger.debug(
-                    "Bot reponse sent: {}".format(message_sent)
+                    "Bot response sent: {}".format(message_sent)
                 )
 
                 if self.conversation.agent.agent_config.end_conversation_on_goodbye:

--- a/vocode/streaming/synthesizer/caching_synthesizer.py
+++ b/vocode/streaming/synthesizer/caching_synthesizer.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import re
+import logging
 from typing import Any, AsyncGenerator, Callable, Optional, List
 from vocode.streaming.agent.bot_sentiment_analyser import BotSentiment
 from vocode.streaming.models.agent import FillerAudioConfig
@@ -61,10 +62,15 @@ class AsyncGeneratorWrapper(AsyncGenerator[SynthesisResult.ChunkResult, None]):
 
 class CachingSynthesizer(BaseSynthesizer):
 
-    def __init__(self, inner_synthesizer: BaseSynthesizer, cache_path: str = "cache"):
+    def __init__(self,
+                 inner_synthesizer: BaseSynthesizer,
+                 cache_path: str = "cache",
+                 logger: Optional[logging.Logger] = None,
+                 ):
         self.should_close_session_on_tear_down = False
         self.inner_synthesizer = inner_synthesizer
         self.cache_path = cache_path
+        self.logger = logger or logging.getLogger(__name__)
         os.makedirs(self.cache_path, exist_ok=True)
     
     @property

--- a/vocode/streaming/synthesizer/caching_synthesizer.py
+++ b/vocode/streaming/synthesizer/caching_synthesizer.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 import re
-import logging
 from typing import Any, AsyncGenerator, Callable, Optional, List
 from vocode.streaming.agent.bot_sentiment_analyser import BotSentiment
 from vocode.streaming.models.agent import FillerAudioConfig

--- a/vocode/streaming/utils/__init__.py
+++ b/vocode/streaming/utils/__init__.py
@@ -73,7 +73,7 @@ def remove_non_letters_digits(text):
 def save_as_wav(path, audio_data: bytes, sampling_rate: int):
     if len(audio_data) == 0:
         logger.info(f"Attempted to save an empty WAV file to {path}. Skipping.")
-        return None
+        return
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "wb") as f:
         wav_file = wave.open(f, "wb")

--- a/vocode/streaming/utils/__init__.py
+++ b/vocode/streaming/utils/__init__.py
@@ -72,8 +72,8 @@ def remove_non_letters_digits(text):
 
 def save_as_wav(path, audio_data: bytes, sampling_rate: int):
     if len(audio_data) == 0:
-        logger.error(f"Cannot save an empty WAV file to {path}")
-        return
+        logger.info(f"Attempted to save an empty WAV file to {path}. Skipping.")
+        return None
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "wb") as f:
         wav_file = wave.open(f, "wb")


### PR DESCRIPTION
Previously, logging will raise Error when attempting to save empty `.wav` file containing 0 bytes.

This commit proposes to lower this to `info`, and returns `None` when `audio_date == 0`.

Currently, we have that `azure_synthesizer.py` returns `SynthesisResult` containing                 `self.empty_generator()`, where the size of the `ChunkResult` is `0` which is not `None`.

This condition is triggered by `if not re.search(r"\w", message.text)`:
Which includes non-alphanumeric characters such as `.`, `-` or ` `. 
So, characters that cannot be pronounced by the synthesizer are omitted.
