### PR TITLE
Fix broken retry logic

### DIFF
--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -188,7 +188,7 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
                     break # Don't retry on other status codes
             except (aiohttp.ClientResponseError, aiohttp.ClientTimeout, aiohttp.ClientConnectionError) as e:
                 # Sleep and retry for retriable errors
-                self.logger.warning(f"Temporary issue accessing ElevenLabs API: {e}. Retrying after delay...")
+                self.logger.warning(f"Temporary issue accessing ElevenLabs API: {e}. Retrying after {delay:.1f}s...")
                 await asyncio.sleep(delay)
                 delay = delay * backoff  # Increase delay for next attempt
             


### PR DESCRIPTION
Previous retry logic would get stuck in the while loop on any other errors than 429, as attempts where not incremented, and the Exception wasn't raised (just created) which meant no info in Sentry or logs.