### PR TITLE
Ensure event manager flush waits for currently processing event

### DIFF
--- a/vocode/streaming/utils/events_manager.py
+++ b/vocode/streaming/utils/events_manager.py
@@ -11,6 +11,7 @@ class EventsManager:
         self.queue: asyncio.Queue[Event] = asyncio.Queue()
         self.subscriptions = set(subscriptions)
         self.active = False
+        self.current_event_done = asyncio.Event()
 
     def publish_event(self, event: Event):
         if event.type in self.subscriptions:
@@ -21,7 +22,9 @@ class EventsManager:
         while self.active:
             try:
                 event = await self.queue.get()
+                self.current_event_done.clear()
                 await self.handle_event(event)
+                self.current_event_done.set()
             except asyncio.QueueEmpty:
                 await asyncio.sleep(1)
             except asyncio.CancelledError:
@@ -38,3 +41,5 @@ class EventsManager:
                 await self.handle_event(event)
             except asyncio.QueueEmpty:
                 break
+        # Await the start() task to finish any currently processing events as well
+        await self.current_event_done.wait()


### PR DESCRIPTION
Previous `flush()` only waited for unhandled events to be done, it would skip any event currently being processed by `start()`. Now we set an event so that we can mark when the current event has finished so that `flush()` can guarantee that all events have been handled when exiting.